### PR TITLE
Fix: Restablecer estado inicial y limpiar búsqueda al volver al inicio

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -293,31 +293,6 @@ const mainPage = () => {
 window.onload = () => {
 	mainPage(); // en lugar de fetchData(...)
 };
-
-
-
-
-/*
-const mainPage = () => {
-  order = "title";
-  offset = 0;
-  fetchData(input, order);
-  pageNumber = 1;
-  searchType.value = "comics";
-  type = searchType.value;
-  searchOrder.innerHTML = `
-    <option value='title'>A/Z</option>
-    <option value='-title'>Z/A</option>
-    <option value='-focDate'>Más nuevos</option>
-    <option value='focDate'>Más viejos</option> 
-    `;
-};
-
-window.onload = () => {
-    fetchData(input, order);
-};
-*/
-
 /*** <<<<<<<<<<<<<<<<<<<<<<< FUNCIONALIDAD LOADER <<<<<<<<<<<<<<<<<<<<<<<>  *******/
 
 function loader(action) {

--- a/js/app.js
+++ b/js/app.js
@@ -275,6 +275,30 @@ const lastPage = (func) => {
 /** <<<<<<<<<<<<<<<<<<<<<<< FUNCIONALIDAD PAGINA INICIO <<<<<<<<<<<<<<<<<<<<<<<>  ***/
 
 const mainPage = () => {
+	order = "title";
+	offset = 0;
+	fetchData("", order); // <-- también pasamos input vacío explícitamente
+	pageNumber = 1;
+	searchInput.value = ""; // <-- limpia el campo de búsqueda
+	searchType.value = "comics";
+	type = searchType.value;
+	searchOrder.innerHTML = `
+    <option value='title'>A/Z</option>
+    <option value='-title'>Z/A</option>
+    <option value='-focDate'>Más nuevos</option>
+    <option value='focDate'>Más viejos</option> 
+  `;
+};
+
+window.onload = () => {
+	mainPage(); // en lugar de fetchData(...)
+};
+
+
+
+
+/*
+const mainPage = () => {
   order = "title";
   offset = 0;
   fetchData(input, order);
@@ -292,6 +316,7 @@ const mainPage = () => {
 window.onload = () => {
     fetchData(input, order);
 };
+*/
 
 /*** <<<<<<<<<<<<<<<<<<<<<<< FUNCIONALIDAD LOADER <<<<<<<<<<<<<<<<<<<<<<<>  *******/
 


### PR DESCRIPTION
Este pull request actualiza la función `mainPage()` en el archivo `app.js` para asegurar que:

- Se limpie correctamente el campo de búsqueda al hacer clic en el botón INICIO.
- Se restablezcan los valores por defecto de tipo y orden de búsqueda (comics, orden A/Z).
- Se oculte la vista de detalles de cómic o personaje.
- Se visualice la primera página con todos los cómics como estado inicial.

Además, se asegura que la llamada a `fetchData()` cargue correctamente todos los cómics desde el principio (offset = 0), y que `pageNumber` se establezca correctamente en 1.

Esta mejora garantiza una experiencia más consistente y predecible para el usuario al volver al estado inicial de la aplicación.
